### PR TITLE
Add dependabot to main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    labels:
+      - "pip dependencies"


### PR DESCRIPTION
Работает только если в ветке main. Еще добавил целевую ветку, в которую будут целиться ПР-ы от депендабота

Из dev-a думаю надо депендабота откатить, сделаю отдельный ПР