### PR TITLE
feat: Add CI on PR back

### DIFF
--- a/.github/workflows/build_and_run.yaml
+++ b/.github/workflows/build_and_run.yaml
@@ -1,6 +1,6 @@
 name: Build and Launch C# Project + Run training
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-and-launch:

--- a/.github/workflows/python_linting.yaml
+++ b/.github/workflows/python_linting.yaml
@@ -1,6 +1,6 @@
 name: Python linting
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -1,6 +1,6 @@
 name: Run python tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-and-launch:


### PR DESCRIPTION
Теперь если кто-то мержится в ветку, которую вы таргетите в другом ПРе, CI не перезапускается, так как `on: pull_request` убрали. Надо вернуть