### PR TITLE
Gameserver upd [2]

### DIFF
--- a/AIAgent/common/classes.py
+++ b/AIAgent/common/classes.py
@@ -1,17 +1,10 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from pathlib import Path
+from dataclasses_json import dataclass_json
 from typing import Optional, TypeAlias
 
-from dataclasses_json import dataclass_json
-from pydantic import Field, field_validator
-from pydantic.dataclasses import dataclass as pydantic_dataclass
-from connection.broker_conn.classes import SVMInfo
 from common.game import GameMap
 from ml.protocols import Named
-
-PlatformName: TypeAlias = str
-SVMInfoName: TypeAlias = str
 
 
 @dataclass_json
@@ -57,52 +50,3 @@ class Map2Result:
 
 GameMapsModelResults: TypeAlias = defaultdict[GameMap, list[Agent2Result]]
 AgentResultsOnGameMaps: TypeAlias = defaultdict[Named, list[Map2Result]]
-
-
-@pydantic_dataclass
-class DatasetConfig:
-    dataset_base_path: Path  # path to dir with explored dlls
-    dataset_description: Path  # full paths to JSON-file with dataset description
-
-    @field_validator("dataset_base_path", "dataset_description", mode="before")
-    @classmethod
-    def transform(cls, input: str) -> Path:
-        return Path(input).resolve()
-
-
-@pydantic_dataclass
-class Platform:
-    name: PlatformName
-    DatasetConfigs: list[DatasetConfig]
-    SVMInfo: SVMInfo
-
-
-@pydantic_dataclass
-class OptunaConfig:
-    n_startup_trials: int  # number of optuna's trials
-    n_trials: int  # number of optuna's trials
-    n_jobs: int
-    study_direction: str
-
-
-@pydantic_dataclass
-class TrainingConfig:
-    dynamic_dataset: bool
-    train_percentage: float
-    threshold_coverage: int
-    load_to_cpu: bool
-    epochs: int
-    threshold_steps_number: Optional[int] = Field(default=None)
-
-
-@pydantic_dataclass
-class Config:
-    Platforms: list[Platform]
-    OptunaConfig: OptunaConfig
-    TrainingConfig: TrainingConfig
-    path_to_weights: Optional[Path] = Field(default=None)
-
-    @field_validator("path_to_weights", mode="before")
-    @classmethod
-    def transform(cls, input: Optional[str]) -> Optional[Path]:
-        return Path(input).absolute() if input is not None else None

--- a/AIAgent/common/config.py
+++ b/AIAgent/common/config.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from typing import Optional
+
+from pydantic import Field, field_validator
+from pydantic.dataclasses import dataclass as pydantic_dataclass
+from connection.broker_conn.classes import SVMInfo
+from common.typealias import PlatformName
+
+
+@pydantic_dataclass
+class DatasetConfig:
+    dataset_base_path: Path  # path to dir with explored dlls
+    dataset_description: Path  # full paths to JSON-file with dataset description
+
+    @field_validator("dataset_base_path", "dataset_description", mode="before")
+    @classmethod
+    def transform(cls, input: str) -> Path:
+        return Path(input).resolve()
+
+
+@pydantic_dataclass
+class Platform:
+    name: PlatformName
+    DatasetConfigs: list[DatasetConfig]
+    SVMSInfo: list[SVMInfo]
+
+
+@pydantic_dataclass
+class ServersConfig:
+    Platforms: list[Platform]
+    count: int
+
+
+@pydantic_dataclass
+class OptunaConfig:
+    n_startup_trials: (
+        int  # number of initial trials with random sampling for optuna's TPESampler
+    )
+    n_trials: int  # number of optuna's trials
+    n_jobs: int
+    study_direction: str
+
+
+@pydantic_dataclass
+class TrainingConfig:
+    dynamic_dataset: bool
+    train_percentage: float
+    threshold_coverage: int
+    load_to_cpu: bool
+    epochs: int
+    threshold_steps_number: Optional[int] = Field(default=None)
+
+
+@pydantic_dataclass
+class Config:
+    ServersConfig: ServersConfig
+    OptunaConfig: OptunaConfig
+    TrainingConfig: TrainingConfig
+    path_to_weights: Optional[Path] = Field(default=None)
+
+    @field_validator("path_to_weights", mode="before")
+    @classmethod
+    def transform(cls, input: Optional[str]) -> Optional[Path]:
+        return Path(input).absolute() if input is not None else None

--- a/AIAgent/common/config.py
+++ b/AIAgent/common/config.py
@@ -21,14 +21,14 @@ class DatasetConfig:
 @pydantic_dataclass
 class Platform:
     name: PlatformName
-    DatasetConfigs: list[DatasetConfig]
-    SVMSInfo: list[SVMInfo]
+    dataset_configs: list[DatasetConfig] = Field(alias="DatasetConfigs")
+    svms_info: list[SVMInfo] = Field(alias="SVMSInfo")
 
 
 @pydantic_dataclass
 class ServersConfig:
-    Platforms: list[Platform]
     count: int
+    platforms: list[Platform] = Field(alias="Platforms")
 
 
 @pydantic_dataclass
@@ -53,9 +53,9 @@ class TrainingConfig:
 
 @pydantic_dataclass
 class Config:
-    ServersConfig: ServersConfig
-    OptunaConfig: OptunaConfig
-    TrainingConfig: TrainingConfig
+    servers_config: ServersConfig = Field(alias="ServersConfig")
+    optuna_config: OptunaConfig = Field(alias="OptunaConfig")
+    training_config: TrainingConfig = Field(alias="TrainingConfig")
     path_to_weights: Optional[Path] = Field(default=None)
 
     @field_validator("path_to_weights", mode="before")

--- a/AIAgent/common/config.py
+++ b/AIAgent/common/config.py
@@ -61,4 +61,4 @@ class Config:
     @field_validator("path_to_weights", mode="before")
     @classmethod
     def transform(cls, input: Optional[str]) -> Optional[Path]:
-        return Path(input).absolute() if input is not None else None
+        return Path(input).resolve() if input is not None else None

--- a/AIAgent/common/errors.py
+++ b/AIAgent/common/errors.py
@@ -1,11 +1,11 @@
 from common.game import GameMap
 
 
-class GamesError(ExceptionGroup):
+class GameErrors(ExceptionGroup):
     def __new__(cls, errors: list[Exception], maps: list[GameMap]):
-        self = super().__new__(GamesError, "There are failed or timeouted maps", errors)
+        self = super().__new__(GameErrors, "There are failed or timeouted maps", errors)
         self.maps = maps
         return self
 
-    def derive(self, exc):
-        return GamesError(self.message, exc)
+    def derive(self, excs):
+        return GameErrors(self.message, excs)

--- a/AIAgent/common/errors.py
+++ b/AIAgent/common/errors.py
@@ -1,0 +1,7 @@
+from common.game import GameMap
+
+
+class GameError(RuntimeError):
+    def __init__(self, message, maps: list[GameMap]):
+        super().__init__(message)
+        self.maps = maps

--- a/AIAgent/common/errors.py
+++ b/AIAgent/common/errors.py
@@ -1,7 +1,11 @@
 from common.game import GameMap
 
 
-class GameError(RuntimeError):
-    def __init__(self, message, maps: list[GameMap]):
-        super().__init__(message)
+class GamesError(ExceptionGroup):
+    def __new__(cls, errors: list[Exception], maps: list[GameMap]):
+        self = super().__new__(GamesError, "There are failed or timeouted maps", errors)
         self.maps = maps
+        return self
+
+    def derive(self, exc):
+        return GamesError(self.message, exc)

--- a/AIAgent/common/game.py
+++ b/AIAgent/common/game.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from dataclasses_json import config, dataclass_json
-from connection.broker_conn.classes import SingleSVMInfo
+from connection.broker_conn.classes import SVMInfo as SVMInfoT
 
 
 @dataclass_json
@@ -74,9 +74,7 @@ class GameMap:
     NameOfObjectToCover: str
     DefaultSearcher: str
     MapName: str
-    SVMInfo: SingleSVMInfo = field(
-        default=None, metadata=config(exclude=lambda x: True)
-    )
+    SVMInfo: SVMInfoT = field(default=None, metadata=config(exclude=lambda x: True))
 
 
 @dataclass_json

--- a/AIAgent/common/typealias.py
+++ b/AIAgent/common/typealias.py
@@ -1,0 +1,4 @@
+from typing import TypeAlias
+
+PlatformName: TypeAlias = str
+SVMName: TypeAlias = str

--- a/AIAgent/config.py
+++ b/AIAgent/config.py
@@ -22,7 +22,7 @@ class WebsocketSourceLinks:
 
 
 @dataclass(slots=True, frozen=True)
-class DumpByTimeoutFeature:
+class SaveIfFailOrTimeout:
     enabled: bool
     timeout_sec: int
     save_path: Path
@@ -44,7 +44,7 @@ class OnGameServerRestartFeature:
 class FeatureConfig:
     VERBOSE_TABLES = True
     DISABLE_MESSAGE_CHECKS = True
-    DUMP_BY_TIMEOUT = DumpByTimeoutFeature(
+    SAVE_IF_FAIL_OR_TIMEOUT = SaveIfFailOrTimeout(
         enabled=True, timeout_sec=1800, save_path=Path("./report/timeouted_agents/")
     )
     ON_GAME_SERVER_RESTART = OnGameServerRestartFeature(
@@ -56,8 +56,8 @@ class GameServerConnectorConfig:
     CREATE_CONNECTION_TIMEOUT_SEC = 1
     WAIT_FOR_SOCKET_RECONNECTION_MAX_RETRIES = 10 * 60
     RESPONCE_TIMEOUT_SEC = (
-        FeatureConfig.DUMP_BY_TIMEOUT.timeout_sec + 1
-        if FeatureConfig.DUMP_BY_TIMEOUT.enabled
+        FeatureConfig.SAVE_IF_FAIL_OR_TIMEOUT.timeout_sec + 1
+        if FeatureConfig.SAVE_IF_FAIL_OR_TIMEOUT.enabled
         else 1000
     )
     SKIP_UTF_VALIDATION = True

--- a/AIAgent/connection/broker_conn/classes.py
+++ b/AIAgent/connection/broker_conn/classes.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
+from dataclasses_json import dataclass_json
 from typing import Callable, TypeAlias
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
+from common.typealias import SVMName
 from config import FeatureConfig
 from connection.game_server_conn.unsafe_json import asdict
-from dataclasses_json import dataclass_json
 
 WSUrl: TypeAlias = str
 Undefined: TypeAlias = None
@@ -13,15 +14,15 @@ Undefined: TypeAlias = None
 @dataclass_json
 @dataclass(slots=True, frozen=True)
 class ServerInstanceInfo:
-    svm_name: str
+    svm_name: SVMName
     port: int
     ws_url: WSUrl
     pid: int | Undefined
 
 
 @pydantic_dataclass(config=dict(extra="ignore"))
-class SingleSVMInfo:
-    name: str
+class SVMInfo:
+    name: SVMName
     launch_command: str
     min_port: int
     max_port: int
@@ -29,14 +30,6 @@ class SingleSVMInfo:
 
     def to_dict(self):  # GameMap class requires the to_dict method for all its fields
         return self.__dict__
-
-
-@pydantic_dataclass
-class SVMInfo(SingleSVMInfo):
-    count: int
-
-    def create_single_svm_info(self) -> SingleSVMInfo:
-        return SingleSVMInfo(**self.__dict__)
 
 
 def custom_encoder_if_disable_message_checks() -> Callable | None:

--- a/AIAgent/connection/broker_conn/requests.py
+++ b/AIAgent/connection/broker_conn/requests.py
@@ -4,12 +4,12 @@ from urllib.parse import urlencode
 
 import httplib2
 from config import WebsocketSourceLinks
-from connection.broker_conn.classes import ServerInstanceInfo, SingleSVMInfo
+from connection.broker_conn.classes import ServerInstanceInfo, SVMInfo
 
 
-def acquire_instance(svm_info: SingleSVMInfo) -> ServerInstanceInfo:
+def acquire_instance(svm_info: SVMInfo) -> ServerInstanceInfo:
     response, content = httplib2.Http().request(
-        WebsocketSourceLinks.GET_WS + "?" + urlencode(SingleSVMInfo.to_dict(svm_info))
+        WebsocketSourceLinks.GET_WS + "?" + urlencode(SVMInfo.to_dict(svm_info))
     )
     if response.status != 200:
         logging.error(f"{response.status} with {content=} on acquire_instance call")

--- a/AIAgent/connection/broker_conn/socket_manager.py
+++ b/AIAgent/connection/broker_conn/socket_manager.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager, suppress
 
 import websocket
 from config import GameServerConnectorConfig
-from connection.broker_conn.classes import ServerInstanceInfo, SingleSVMInfo
+from connection.broker_conn.classes import ServerInstanceInfo, SVMInfo
 from connection.broker_conn.requests import acquire_instance, return_instance
 
 
@@ -37,7 +37,7 @@ def wait_for_connection(server_instance: ServerInstanceInfo):
 
 
 @contextmanager
-def game_server_socket_manager(svm_info: SingleSVMInfo):
+def game_server_socket_manager(svm_info: SVMInfo):
     server_instance = acquire_instance(svm_info)
 
     socket = wait_for_connection(server_instance)

--- a/AIAgent/launch_servers.py
+++ b/AIAgent/launch_servers.py
@@ -226,7 +226,7 @@ def main(config: str):
     with open(config, "r") as file:
         trainings_parameters = yaml.safe_load(file)
     config: Config = Config(**trainings_parameters)
-    server_count = config.ServersConfig.count
+    server_count = config.servers_config.count
 
     with server_manager(SERVER_INSTANCES, server_count):
         app = web.Application()

--- a/AIAgent/ml/play_game.py
+++ b/AIAgent/ml/play_game.py
@@ -3,7 +3,7 @@ from time import perf_counter
 import traceback
 from typing import TypeAlias
 
-from common.errors import GamesError
+from common.errors import GameErrors
 from common.classes import GameResult, Map2Result
 from common.game import GameMap, GameState
 from config import FeatureConfig
@@ -179,6 +179,6 @@ def play_game(
             with_predictor.model(), with_name=f"{with_predictor.name()}"
         )
         failed_maps, errors = list(zip(*list_of_failed_maps_with_errors))
-        raise GamesError(errors, failed_maps)
+        raise GameErrors(errors, failed_maps)
 
     return list_of_map2result

--- a/AIAgent/ml/training/validation.py
+++ b/AIAgent/ml/training/validation.py
@@ -5,7 +5,7 @@ from typing import Callable
 import numpy as np
 import torch
 import tqdm
-from common.errors import GamesError
+from common.errors import GameErrors
 from epochs_statistics import StatisticsCollector
 from config import GeneralConfig
 from ml.inference import infer
@@ -74,7 +74,7 @@ def validate_coverage(
             ncols=100,
             colour=progress_bar_colour,
         ):
-            if isinstance(result, GamesError):
+            if isinstance(result, GameErrors):
                 statistics_collector.fail(result.maps)
             else:
                 all_results.extend(result)

--- a/AIAgent/ml/training/validation.py
+++ b/AIAgent/ml/training/validation.py
@@ -5,7 +5,7 @@ from typing import Callable
 import numpy as np
 import torch
 import tqdm
-from common.errors import GameError
+from common.errors import GamesError
 from epochs_statistics import StatisticsCollector
 from config import GeneralConfig
 from ml.inference import infer
@@ -65,7 +65,6 @@ def validate_coverage(
     """
     wrapper = TrainingModelWrapper(model)
     tasks = [([game_map], dataset, wrapper) for game_map in dataset.maps]
-    error: Exception | None = None
     with mp.Pool(server_count) as p:
         all_results = []
         for result in tqdm.tqdm(
@@ -75,16 +74,10 @@ def validate_coverage(
             ncols=100,
             colour=progress_bar_colour,
         ):
-            if isinstance(result, GameError):
+            if isinstance(result, GamesError):
                 statistics_collector.fail(result.maps)
-            elif isinstance(
-                result, Exception  # that means that error is not handled
-            ):  # it is not possible to raise an exception here or to terminate pool due to the pool hanging
-                error = result
             else:
                 all_results.extend(result)
-    if isinstance(error, Exception):
-        raise error
     print(
         "Average dataset state result",
         np.average(

--- a/AIAgent/run_training.py
+++ b/AIAgent/run_training.py
@@ -88,10 +88,10 @@ def run_training(
     )
 
     maps: list[GameMap] = list()
-    for platform in servers_config.Platforms:
-        svms_info = platform.SVMSInfo
+    for platform in servers_config.platforms:
+        svms_info = platform.svms_info
         for svm_info in svms_info:
-            for dataset_config in platform.DatasetConfigs:
+            for dataset_config in platform.dataset_configs:
                 dataset_base_path = dataset_config.dataset_base_path
                 dataset_description = dataset_config.dataset_description
                 with open(dataset_description, "r") as maps_json:
@@ -241,9 +241,9 @@ def main(config: str):
         path_to_weights = Path(path_to_weights).absolute()
 
     run_training(
-        servers_config=config.ServersConfig,
-        optuna_config=config.OptunaConfig,
-        training_config=config.TrainingConfig,
+        servers_config=config.servers_config,
+        optuna_config=config.optuna_config,
+        training_config=config.training_config,
         path_to_weights=path_to_weights,
         logfile_base_name=logfile_base_name,
         statistics_collector=statistics_collector,

--- a/workflow/config_for_tests.yml
+++ b/workflow/config_for_tests.yml
@@ -1,27 +1,26 @@
-Platforms:
-  - name: dotnet
-    DatasetConfigs:
-      - dataset_base_path: ../maps/DotNet/Maps/Root/bin/Release/net7.0
-        dataset_description: ../workflow/dataset_for_tests_net.json
-    SVMInfo:
-      name: VSharp
-      count: 1
-      launch_command: dotnet VSharp.ML.GameServer.Runner.dll --mode server --port {port}
-      min_port: 35000
-      max_port: 35050
-      server_working_dir: ../GameServers/VSharp/VSharp.ML.GameServer.Runner/bin/Release/net7.0
-
-  - name: java
-    DatasetConfigs:
-      - dataset_base_path: ../maps/Java/Maps/
-        dataset_description: ../workflow/dataset_for_tests_java.json
-    SVMInfo:
-      name: usvm
-      count: 1
-      launch_command: java -jar app.jar --mode server --port {port}
-      min_port: 35100
-      max_port: 35150
-      server_working_dir: ../GameServers/usvm/usvm-ml-gameserver/build/libs/
+ServersConfig:
+  Platforms:
+    - name: dotnet
+      DatasetConfigs:
+        - dataset_base_path: ../maps/DotNet/Maps/Root/bin/Release/net7.0
+          dataset_description: ../workflow/dataset_for_tests_net.json
+      SVMSInfo:
+        - name: VSharp
+          launch_command: dotnet VSharp.ML.GameServer.Runner.dll --mode server --port {port}
+          min_port: 35000
+          max_port: 35050
+          server_working_dir: ../GameServers/VSharp/VSharp.ML.GameServer.Runner/bin/Release/net7.0
+    - name: java
+      DatasetConfigs:
+        - dataset_base_path: ../maps/Java/Maps/
+          dataset_description: ../workflow/dataset_for_tests_java.json
+      SVMSInfo:
+        - name: usvm
+          launch_command: java -jar app.jar --mode server --port {port}
+          min_port: 35100
+          max_port: 35150
+          server_working_dir: ../GameServers/usvm/usvm-ml-gameserver/build/libs/
+  count: 1
 OptunaConfig:
   n_startup_trials: 1
   n_trials: 1

--- a/workflow/config_for_tests.yml
+++ b/workflow/config_for_tests.yml
@@ -10,7 +10,7 @@ Platforms:
       min_port: 35000
       max_port: 35050
       server_working_dir: ../GameServers/VSharp/VSharp.ML.GameServer.Runner/bin/Release/net7.0
-    
+
   - name: java
     DatasetConfigs:
       - dataset_base_path: ../maps/Java/Maps/
@@ -22,17 +22,14 @@ Platforms:
       min_port: 35100
       max_port: 35150
       server_working_dir: ../GameServers/usvm/usvm-ml-gameserver/build/libs/
-
 OptunaConfig:
   n_startup_trials: 1
   n_trials: 1
   n_jobs: 1
-  study_direction: 'maximize'
-
+  study_direction: "maximize"
 TrainingConfig:
   dynamic_dataset: True
   train_percentage: 1
   threshold_coverage: 100
   load_to_cpu: False
   epochs: 2
-  


### PR DESCRIPTION
- Добавлена обработка ошибок и тайм-аутов карт: в таком случае она удаляется из датасета и больше не учитывается в следующих поколениях. Обучение не прерывается.
- Переписан модуль со статистикой (теперь c оглядкой на то, что процесс обучения единый)
- В конфиге вынесено количество серверов на уровень `ServersConfig`, вместо `SVMInfo` 
- В конфиге поддержана возможность применения нескольких SVM для одной платформы 